### PR TITLE
Remove reference to non-existing constant

### DIFF
--- a/paypal.php
+++ b/paypal.php
@@ -289,7 +289,6 @@ class PayPal extends \PaymentModule
         \Configuration::deleteByName(static::LIVE);
 
         \Configuration::deleteByName(static::IMMEDIATE_CAPTURE);
-        \Configuration::deleteByName(static::DEBUG_MODE);
         \Configuration::deleteByName(static::STORE_COUNTRY);
 
         \Configuration::deleteByName(static::LOGIN_ENABLED);


### PR DESCRIPTION
Missing DEBUG_MODE constant is blocking uninstall procedure