### PR TITLE
Bugfixes and several features

### DIFF
--- a/classes/PayPalLogin.php
+++ b/classes/PayPalLogin.php
@@ -280,11 +280,8 @@ class PayPalLogin
                 $customer = $this->setCustomer($result);
             }
 
-            $login->account_type = $result->account_type;
             $login->user_id = $result->user_id;
             $login->verified_account = $result->verified_account;
-            $login->zoneinfo = $result->zoneinfo;
-            $login->age_range = $result->age_range;
 
             return $customer;
         }

--- a/classes/PayPalLoginUser.php
+++ b/classes/PayPalLoginUser.php
@@ -47,11 +47,8 @@ class PayPalLoginUser extends \ObjectModel
             'refresh_token'    => ['type' => self::TYPE_STRING, 'validate' => 'isString',     'required' => true, 'db_type' => 'VARCHAR(255)'],
             'id_token'         => ['type' => self::TYPE_STRING, 'validate' => 'isString',     'required' => true, 'db_type' => 'VARCHAR(255)'],
             'access_token'     => ['type' => self::TYPE_STRING, 'validate' => 'isString',     'required' => true, 'db_type' => 'VARCHAR(255)'],
-            'account_type'     => ['type' => self::TYPE_STRING, 'validate' => 'isString',     'required' => true, 'db_type' => 'VARCHAR(255)'],
             'user_id'          => ['type' => self::TYPE_STRING, 'validate' => 'isString',     'required' => true, 'db_type' => 'VARCHAR(255)'],
             'verified_account' => ['type' => self::TYPE_STRING, 'validate' => 'isString',     'required' => true, 'db_type' => 'VARCHAR(255)'],
-            'zoneinfo'         => ['type' => self::TYPE_STRING, 'validate' => 'isString',     'required' => true, 'db_type' => 'VARCHAR(255)'],
-            'age_range'        => ['type' => self::TYPE_STRING, 'validate' => 'isString',     'required' => true, 'db_type' => 'VARCHAR(255)'],
         ],
     ];
     /** @var int $id_customer */
@@ -66,16 +63,10 @@ class PayPalLoginUser extends \ObjectModel
     public $id_token;
     /** @var string $access_token */
     public $access_token;
-    /** @var string $account_type */
-    public $account_type;
     /** @var string $user_id */
     public $user_id;
     /** @var string $verified_account */
     public $verified_account;
-    /** @var string $zoneinfo */
-    public $zoneinfo;
-    /** @var string $age_range */
-    public $age_range;
     // @codingStandardsIgnoreEnd
 
     /**

--- a/classes/PayPalRestApi.php
+++ b/classes/PayPalRestApi.php
@@ -79,6 +79,24 @@ class PayPalRestApi
         $this->secret = ($secret) ? $secret : \Configuration::get(\PayPal::SECRET);
     }
 
+    private function getWebProfileId($type)
+    {
+        switch ($type) {
+            case self::PLUS_PROFILE:
+                return (\Configuration::get(\PayPal::LIVE))
+                    ? \Configuration::get(\PayPal::PLUS_WEBSITE_PROFILE_ID_LIVE)
+                    : \Configuration::get(\PayPal::PLUS_WEBSITE_PROFILE_ID);
+            case self::EXPRESS_CHECKOUT_PROFILE:
+                return (\Configuration::get(\PayPal::LIVE))
+                    ? \Configuration::get(\PayPal::EXPRESS_CHECKOUT_WEBSITE_PROFILE_ID_LIVE)
+                    : \Configuration::get(\PayPal::EXPRESS_CHECKOUT_WEBSITE_PROFILE_ID);
+            default:
+                return (\Configuration::get(\PayPal::LIVE))
+                    ? \Configuration::get(\PayPal::STANDARD_WEBSITE_PROFILE_ID_LIVE)
+                    : \Configuration::get(\PayPal::STANDARD_WEBSITE_PROFILE_ID);
+        }
+    }
+
     /**
      * @param int $type
      *
@@ -88,38 +106,55 @@ class PayPalRestApi
      * @copyright 2007-2016 PrestaShop SA
      * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
      */
-    public function getWebProfile($type = self::STANDARD_PROFILE)
+    public function createWebProfile($type = self::STANDARD_PROFILE)
     {
         $accessToken = $this->getToken();
 
         if ($accessToken) {
-            $data = $this->createWebProfile($type);
+            $data = $this->getWebProfileDefinition($type);
 
             $headers = [
                 'Content-Type'  => 'application/json',
                 'Authorization' => 'Bearer '.$accessToken,
             ];
 
-            if ($this->profiles) {
-                $profileId = '';
-                foreach ($this->profiles as $profile) {
-                    if ($profile->name == $data['name']) {
-                        $profileId = $profile->id;
-                    }
-                }
+            // DELETE if profile exists
+            $profileId = $this->getWebProfileId($type);
+            $this->deleteWebProfile($profileId);
 
-                if ($profileId) {
-                    // DELETE first
-                    $this->send(self::PATH_WEBPROFILES.'/'.$profileId, false, $headers, false, 'DELETE');
-                }
-            }
-
-            // Then create
+            // Then CREATE
             $result = json_decode($this->send(self::PATH_WEBPROFILES, json_encode($data), $headers, false, 'POST'));
 
             if (isset($result->id)) {
                 return $result->id;
             }
+        }
+
+        return false;
+    }
+
+    public function deleteWebProfile($type)
+    {
+        $accessToken = $this->getToken();
+
+        if ($accessToken) {
+            $data = $this->getWebProfileDefinition($type);
+
+            $headers = [
+                'Content-Type'  => 'application/json',
+                'Authorization' => 'Bearer '.$accessToken,
+            ];
+
+            // CHECK if profile exists
+            $profileId = $this->getWebProfileId($type);
+            if (!empty($profileId)) {
+                $profile = json_decode($this->send(self::PATH_WEBPROFILES.'/'.$profileId, false, $headers));
+                // then DELETE
+                if (isset($profile->id) && $profile->id == $profileId) {
+                    $this->send(self::PATH_WEBPROFILES.'/'.$profileId, false, $headers, false, 'DELETE');
+                }
+            }
+            return true; // It just matters that the profile does not exist now
         }
 
         return false;
@@ -435,32 +470,7 @@ class PayPalRestApi
             'payer'        => $payer,
             'intent'       => 'sale',
         ];
-        if (\Configuration::get(\PayPal::LIVE)) {
-            switch ($profile) {
-                case self::PLUS_PROFILE:
-                    $payment->experience_profile_id = \Configuration::get(\PayPal::PLUS_WEBSITE_PROFILE_ID_LIVE);
-                    break;
-                case self::EXPRESS_CHECKOUT_PROFILE:
-                    $payment->experience_profile_id = \Configuration::get(\PayPal::EXPRESS_CHECKOUT_WEBSITE_PROFILE_ID_LIVE);
-                    break;
-                default:
-                    $payment->experience_profile_id = \Configuration::get(\PayPal::STANDARD_WEBSITE_PROFILE_ID_LIVE);
-                    break;
-            }
-        } else {
-            switch ($profile) {
-                case self::PLUS_PROFILE:
-                    $payment->experience_profile_id = \Configuration::get(\PayPal::PLUS_WEBSITE_PROFILE_ID);
-                    break;
-                case self::EXPRESS_CHECKOUT_PROFILE:
-                    $payment->experience_profile_id = \Configuration::get(\PayPal::EXPRESS_CHECKOUT_WEBSITE_PROFILE_ID);
-                    break;
-                default:
-                    $payment->experience_profile_id = \Configuration::get(\PayPal::STANDARD_WEBSITE_PROFILE_ID);
-                    break;
-            }
-        }
-
+        $payment->experience_profile_id = $this->getWebProfileId($profile);
         $payment->redirect_urls = $redirectUrls;
         // d($payment);
         return $payment;
@@ -583,7 +593,7 @@ class PayPalRestApi
      * @copyright 2007-2016 PrestaShop SA
      * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
      */
-    protected function createWebProfile($type)
+    protected function getWebProfileDefinition($type)
     {
         $name = 'thirtybees_'.(int) $this->context->shop->id.'_'.(int) $type;
         $idLang = (int) \Configuration::get('PS_LANG_DEFAULT');

--- a/classes/PayPalRestApi.php
+++ b/classes/PayPalRestApi.php
@@ -596,7 +596,9 @@ class PayPalRestApi
      */
     protected function getWebProfileDefinition($type, $adjustLogo = true)
     {
-        $name = 'thirtybees_'.(int) $this->context->shop->id.'_'.(int) $type;
+        $shop_id = (int) $this->context->shop->id;
+        $type_id = (int) $type;
+        $name = "thirtybees_{$shop_id}_{$type_id}_v2";
         $idLang = (int) \Configuration::get('PS_LANG_DEFAULT');
         $language = new \Language($idLang);
         $iso = \Validate::isLoadedObject($language) ? strtolower($language->iso_code) : 'en';
@@ -612,8 +614,8 @@ class PayPalRestApi
                 $dstHeight = $height * $ratio;
 
                 $ext = substr($logo, strrpos($logo, '.') + 1);
-                \ImageManager::resize($logo, _PS_IMG_DIR_."logo_paypal_resized.{$ext}", $dstWidth, $dstHeight, $ext);
-                $logoUrl = _PS_BASE_URL_SSL_._PS_IMG_."logo_paypal_resized.{$ext}";
+                \ImageManager::resize($logo, _PS_IMG_DIR_."logo_{$shop_id}_paypal_resized.{$ext}", $dstWidth, $dstHeight, $ext);
+                $logoUrl = _PS_BASE_URL_SSL_._PS_IMG_."logo_{$shop_id}_paypal_resized.{$ext}";
             }
         }
 

--- a/classes/PayPalRestApi.php
+++ b/classes/PayPalRestApi.php
@@ -138,8 +138,6 @@ class PayPalRestApi
         $accessToken = $this->getToken();
 
         if ($accessToken) {
-            $data = $this->getWebProfileDefinition($type, false);
-
             $headers = [
                 'Content-Type'  => 'application/json',
                 'Authorization' => 'Bearer '.$accessToken,

--- a/classes/PayPalRestApi.php
+++ b/classes/PayPalRestApi.php
@@ -633,7 +633,6 @@ class PayPalRestApi
                     ],
                     'flow_config'  => [
                         'landing_page_type' => 'billing',
-                        'user_action' => 'commit',
                     ],
                 ];
             case self::EXPRESS_CHECKOUT_PROFILE:
@@ -646,12 +645,11 @@ class PayPalRestApi
                     ],
                     'input_fields' => [
                         'allow_note'       => false,
-                        'no_shipping'      => 1,
+                        'no_shipping'      => 2,
                         'address_override' => 0,
                     ],
                     'flow_config'  => [
                         'landing_page_type' => 'billing',
-                        'user_action' => 'commit',
                     ],
                 ];
             default:

--- a/classes/PayPalRestApi.php
+++ b/classes/PayPalRestApi.php
@@ -410,17 +410,17 @@ class PayPalRestApi
         $amount = (object) [
             'total'    => "".round($totalCartWithTax, 2)."",
             'currency' => $oCurrency->iso_code,
-           // 'details'  => $details,
+            'details'  => $details,
         ];
 
         /* Transaction */
         $transaction = (object) [
             'amount'      => $amount,
-           // 'description' => 'Payment description',
-           // 'item_list'   => [
-            //    'items' => $aItems,
-            //    'shipping_address' => \Validate::isLoadedObject($address) ? $shippingAddress : null,
-           // ],
+            // 'description' => 'Payment description',
+            'item_list'   => [
+                'items' => $aItems,
+                'shipping_address' => \Validate::isLoadedObject($address) ? $shippingAddress : null,
+            ],
         ];
 
         /* Redirect Url */
@@ -438,10 +438,10 @@ class PayPalRestApi
         if (\Configuration::get(\PayPal::LIVE)) {
             switch ($profile) {
                 case self::PLUS_PROFILE:
-                    $payment->experience_profile_id = \Configuration::get(\PayPal::STANDARD_WEBSITE_PROFILE_ID_LIVE);
+                    $payment->experience_profile_id = \Configuration::get(\PayPal::PLUS_WEBSITE_PROFILE_ID_LIVE);
                     break;
                 case self::EXPRESS_CHECKOUT_PROFILE:
-                    $payment->experience_profile_id = \Configuration::get(\PayPal::STANDARD_WEBSITE_PROFILE_ID_LIVE);
+                    $payment->experience_profile_id = \Configuration::get(\PayPal::EXPRESS_CHECKOUT_WEBSITE_PROFILE_ID_LIVE);
                     break;
                 default:
                     $payment->experience_profile_id = \Configuration::get(\PayPal::STANDARD_WEBSITE_PROFILE_ID_LIVE);
@@ -450,10 +450,10 @@ class PayPalRestApi
         } else {
             switch ($profile) {
                 case self::PLUS_PROFILE:
-                    $payment->experience_profile_id = \Configuration::get(\PayPal::STANDARD_WEBSITE_PROFILE_ID);
+                    $payment->experience_profile_id = \Configuration::get(\PayPal::PLUS_WEBSITE_PROFILE_ID);
                     break;
                 case self::EXPRESS_CHECKOUT_PROFILE:
-                    $payment->experience_profile_id = \Configuration::get(\PayPal::STANDARD_WEBSITE_PROFILE_ID);
+                    $payment->experience_profile_id = \Configuration::get(\PayPal::EXPRESS_CHECKOUT_WEBSITE_PROFILE_ID);
                     break;
                 default:
                     $payment->experience_profile_id = \Configuration::get(\PayPal::STANDARD_WEBSITE_PROFILE_ID);
@@ -462,7 +462,7 @@ class PayPalRestApi
         }
 
         $payment->redirect_urls = $redirectUrls;
-// d($payment);
+        // d($payment);
         return $payment;
     }
 
@@ -596,7 +596,7 @@ class PayPalRestApi
                     'name'         => $name,
                     'presentation' => [
                         'brand_name'  => \Configuration::get('PS_SHOP_NAME'),
-                        'logo_image'  => _PS_BASE_URL_._PS_IMG_.\Configuration::get('PS_LOGO'),
+                        'logo_image'  => _PS_BASE_URL_SSL_._PS_IMG_.\Configuration::get('PS_LOGO'),
                         'locale_code' => \PayPal::getLocaleByIso($iso),
                     ],
                     'input_fields' => [
@@ -606,6 +606,7 @@ class PayPalRestApi
                     ],
                     'flow_config'  => [
                         'landing_page_type' => 'billing',
+                        'user_action' => 'commit',
                     ],
                 ];
             case self::EXPRESS_CHECKOUT_PROFILE:
@@ -613,7 +614,7 @@ class PayPalRestApi
                     'name'         => $name,
                     'presentation' => [
                         'brand_name'  => \Configuration::get('PS_SHOP_NAME'),
-                        'logo_image'  => _PS_BASE_URL_._PS_IMG_.\Configuration::get('PS_LOGO'),
+                        'logo_image'  => _PS_BASE_URL_SSL_._PS_IMG_.\Configuration::get('PS_LOGO'),
                         'locale_code' => \PayPal::getLocaleByIso($iso),
                     ],
                     'input_fields' => [
@@ -623,6 +624,7 @@ class PayPalRestApi
                     ],
                     'flow_config'  => [
                         'landing_page_type' => 'billing',
+                        'user_action' => 'commit',
                     ],
                 ];
             default:
@@ -630,7 +632,7 @@ class PayPalRestApi
                     'name'         => $name,
                     'presentation' => [
                         'brand_name'  => \Configuration::get('PS_SHOP_NAME'),
-                        'logo_image'  => _PS_BASE_URL_._PS_IMG_.\Configuration::get('PS_LOGO'),
+                        'logo_image'  => _PS_BASE_URL_SSL_._PS_IMG_.\Configuration::get('PS_LOGO'),
                         'locale_code' => \PayPal::getLocaleByIso($iso),
                     ],
                     'input_fields' => [
@@ -640,6 +642,7 @@ class PayPalRestApi
                     ],
                     'flow_config'  => [
                         'landing_page_type' => 'billing',
+                        'user_action' => 'commit',
                     ],
                 ];
         }

--- a/classes/PayPalRestApi.php
+++ b/classes/PayPalRestApi.php
@@ -641,7 +641,7 @@ class PayPalRestApi
                         'address_override' => 1,
                     ],
                     'flow_config'  => [
-                        'landing_page_type' => 'billing',
+                        'landing_page_type' => (\Configuration::get(\PayPal::WEBSITE_PAYMENTS_STANDARD_LANDING_PAGE_TYPE) == 'login') ? 'login' : 'billing',
                         'user_action' => 'commit',
                     ],
                 ];

--- a/controllers/front/expresscheckout.php
+++ b/controllers/front/expresscheckout.php
@@ -94,7 +94,6 @@ class PayPalexpresscheckoutModuleFrontController extends \ModuleFrontController
 
         if (isset($payment->message)) {
             $this->errors[] = $payment->message;
-            // TODO: implement logging
             $this->errors[] = print_r($payment->details, TRUE);
         }
     }

--- a/controllers/front/expresscheckout.php
+++ b/controllers/front/expresscheckout.php
@@ -94,6 +94,8 @@ class PayPalexpresscheckoutModuleFrontController extends \ModuleFrontController
 
         if (isset($payment->message)) {
             $this->errors[] = $payment->message;
+            // TODO: implement logging
+            $this->errors[] = print_r($payment->details, TRUE);
         }
     }
 

--- a/controllers/front/incontextvalidate.php
+++ b/controllers/front/incontextvalidate.php
@@ -137,6 +137,7 @@ class paypalincontextvalidateModuleFrontController extends ModuleFrontController
                 die(json_encode(['success' => false]));
             }
         }
+        die(json_encode(['success' => false, 'reason' => 'Invalid parameters passed.']));
     }
 
     /**

--- a/controllers/front/incontextvalidate.php
+++ b/controllers/front/incontextvalidate.php
@@ -51,7 +51,6 @@ class paypalincontextvalidateModuleFrontController extends ModuleFrontController
 
         if ($this->payerId && $this->paymentId) {
             $callApiPaypalPlus = new PayPalRestApi();
-            $callApiPaypalPlus->getWebProfile();
             $payment = $callApiPaypalPlus->lookUpPayment($this->paymentId);
             $email = $payment->payer->payer_info->email;
             /* Create Customer if not exist with address etc */

--- a/paypal.php
+++ b/paypal.php
@@ -1226,11 +1226,20 @@ class PayPal extends PaymentModule
         $paymentOptions = [];
 
         if (Configuration::get(static::WEBSITE_PAYMENTS_STANDARD_ENABLED)) {
-            $paymentOptions[] = [
-                'cta_text' => $this->l('PayPal or credit card'),
-                'logo'     => Media::getMediaPath($this->_path.'views/img/default_logos/default_horizontal_large.png'),
-                'action'   => $this->context->link->getModuleLink($this->name, 'expresscheckout', [], true),
-            ];
+            if (Configuration::get(static::WEBSITE_PAYMENTS_STANDARD_LANDING_PAGE_TYPE) == 'login') {
+                $paymentOptions[] = [
+                    'cta_text' => $this->l('PayPal'),
+                    'logo'     => Media::getMediaPath($this->_path.'logo.png'),
+                    'action'   => $this->context->link->getModuleLink($this->name, 'expresscheckout', [], true),
+                ];
+            }
+            else {
+                $paymentOptions[] = [
+                    'cta_text' => $this->l('PayPal or credit card'),
+                    'logo'     => Media::getMediaPath($this->_path.'views/img/default_logos/default_horizontal_large.png'),
+                    'action'   => $this->context->link->getModuleLink($this->name, 'expresscheckout', [], true),
+                ];
+            }
         }
 
         if (Configuration::get(static::WEBSITE_PAYMENTS_PLUS_ENABLED)) {

--- a/paypal.php
+++ b/paypal.php
@@ -679,6 +679,7 @@ class PayPal extends PaymentModule
                         'type'     => 'select',
                         'label'    => $this->l('Landing Page Type'),
                         'name'     => static::WEBSITE_PAYMENTS_STANDARD_LANDING_PAGE_TYPE,
+                        'desc'     => $this->l('"Billing" allows credit card payment without a PayPal account, while selecing "Login" requires the customer having a PayPal account. Creating a PayPal account during the payment process is possible with both modes.'),
                         'options'  => [
                             'query' => [
                                 [

--- a/paypal.php
+++ b/paypal.php
@@ -889,8 +889,10 @@ class PayPal extends PaymentModule
             ]
         );
 
-        $process = $this->display(__FILE__, 'views/templates/front/paypaljs.tpl');
-        $process .= '<script async defer type="text/javascript" src="//www.paypalobjects.com/api/checkout.js"></script>';
+        if (Configuration::get(static::LOGIN_ENABLED) || Configuration::get(static::EXPRESS_CHECKOUT_ENABLED)) {
+            $process = $this->display(__FILE__, 'views/templates/front/paypaljs.tpl');
+            $process .= '<script async defer type="text/javascript" src="//www.paypalobjects.com/api/checkout.js"></script>';
+        }
 
         if ((
                 (method_exists($smarty, 'getTemplateVars') && ($smarty->getTemplateVars('page_name')

--- a/paypal.php
+++ b/paypal.php
@@ -89,6 +89,11 @@ class PayPal extends PaymentModule
     const TLS_LAST_CHECK = 'PAYPAL_TLS_LAST_CHECK';
     const ENUM_TLS_OK = 1;
     const ENUM_TLS_ERROR = -1;
+
+    const WEBSITE_PAYMENTS_STANDARD_LANDING_PAGE_TYPE = 'PAYPAL_WPS_LANDING_PAGE_TYPE';
+    const WEBSITE_PAYMENTS_PLUS_LANDING_PAGE_TYPE = 'PAYPAL_WPP_LANDING_PAGE_TYPE';
+    const EXPRESS_CHECKOUT_LANDING_PAGE_TYPE = 'PAYPAL_EC_LANDING_PAGE_TYPE';
+
     // @codingStandardsIgnoreStart
     /** @var array $errors */
     public $errors = [];
@@ -352,6 +357,20 @@ class PayPal extends PaymentModule
             Configuration::updateValue(static::CLIENT_ID, Tools::getValue(static::CLIENT_ID));
             Configuration::updateValue(static::SECRET, Tools::getValue(static::SECRET));
 
+            // Website Payments Standard
+            Configuration::updateValue(static::WEBSITE_PAYMENTS_STANDARD_ENABLED, Tools::getValue(static::WEBSITE_PAYMENTS_STANDARD_ENABLED));
+            Configuration::updateValue(static::WEBSITE_PAYMENTS_STANDARD_LANDING_PAGE_TYPE, Tools::getValue(static::WEBSITE_PAYMENTS_STANDARD_LANDING_PAGE_TYPE));
+
+            // Website Payments Plus
+            Configuration::updateValue(static::WEBSITE_PAYMENTS_PLUS_ENABLED, Tools::getValue(static::WEBSITE_PAYMENTS_PLUS_ENABLED));
+
+            // Express Checkout
+            Configuration::updateValue(static::EXPRESS_CHECKOUT_ENABLED, Tools::getValue(static::EXPRESS_CHECKOUT_ENABLED));
+
+            // PayPal Login
+            Configuration::updateValue(static::LOGIN_ENABLED, (int) Tools::getValue(static::LOGIN_ENABLED));
+            Configuration::updateValue(static::LOGIN_THEME, (int) Tools::getValue(static::LOGIN_THEME));
+
             if (Tools::getValue(static::CLIENT_ID) && Tools::getValue(static::SECRET)) {
                 $rest = new PayPalRestApi(Tools::getValue(static::CLIENT_ID), Tools::getValue(static::SECRET));
                 $rest->getWebProfiles();
@@ -381,19 +400,6 @@ class PayPal extends PaymentModule
                     }
                 }
             }
-
-            // Website Payments Standard
-            Configuration::updateValue(static::WEBSITE_PAYMENTS_STANDARD_ENABLED, Tools::getValue(static::WEBSITE_PAYMENTS_STANDARD_ENABLED));
-
-            // Website Payments Plus
-            Configuration::updateValue(static::WEBSITE_PAYMENTS_PLUS_ENABLED, Tools::getValue(static::WEBSITE_PAYMENTS_PLUS_ENABLED));
-
-            // Express Checkout
-            Configuration::updateValue(static::EXPRESS_CHECKOUT_ENABLED, Tools::getValue(static::EXPRESS_CHECKOUT_ENABLED));
-
-            // PayPal Login
-            Configuration::updateValue(static::LOGIN_ENABLED, (int) Tools::getValue(static::LOGIN_ENABLED));
-            Configuration::updateValue(static::LOGIN_THEME, (int) Tools::getValue(static::LOGIN_THEME));
         }
     }
 
@@ -472,6 +478,8 @@ class PayPal extends PaymentModule
             static::STANDARD_WEBSITE_PROFILE_ID => Configuration::get(static::STANDARD_WEBSITE_PROFILE_ID),
 
             static::WEBSITE_PAYMENTS_STANDARD_ENABLED => Configuration::get(static::WEBSITE_PAYMENTS_STANDARD_ENABLED),
+            static::WEBSITE_PAYMENTS_STANDARD_LANDING_PAGE_TYPE => Configuration::get(static::WEBSITE_PAYMENTS_STANDARD_LANDING_PAGE_TYPE),
+
             static::WEBSITE_PAYMENTS_PLUS_ENABLED     => Configuration::get(static::WEBSITE_PAYMENTS_PLUS_ENABLED),
             static::EXPRESS_CHECKOUT_ENABLED          => Configuration::get(static::EXPRESS_CHECKOUT_ENABLED),
             static::LOGIN_ENABLED                     => Configuration::get(static::LOGIN_ENABLED),
@@ -634,6 +642,27 @@ class PayPal extends PaymentModule
                                 'value' => 0,
                                 'label' => $this->l('Disabled'),
                             ],
+                        ],
+                    ],
+                    [
+                        'type'     => 'select',
+                        'label'    => $this->l('Landing Page Type'),
+                        'name'     => static::WEBSITE_PAYMENTS_STANDARD_LANDING_PAGE_TYPE,
+                        'options'  => [
+                            'query' => [
+                                [
+                                    'id' => 'billing',
+                                    'value' => 'billing',
+                                    'name' => $this->l('Billing'),
+                                ],
+                                [
+                                    'id' => 'login',
+                                    'value' => 'login',
+                                    'name' => $this->l('Login'),
+                                ],
+                            ],
+                            'id'    => 'id',
+                            'name'  => 'name',
                         ],
                     ],
                 ],

--- a/paypal.php
+++ b/paypal.php
@@ -91,8 +91,6 @@ class PayPal extends PaymentModule
     const ENUM_TLS_ERROR = -1;
 
     const WEBSITE_PAYMENTS_STANDARD_LANDING_PAGE_TYPE = 'PAYPAL_WPS_LANDING_PAGE_TYPE';
-    const WEBSITE_PAYMENTS_PLUS_LANDING_PAGE_TYPE = 'PAYPAL_WPP_LANDING_PAGE_TYPE';
-    const EXPRESS_CHECKOUT_LANDING_PAGE_TYPE = 'PAYPAL_EC_LANDING_PAGE_TYPE';
 
     // @codingStandardsIgnoreStart
     /** @var array $errors */
@@ -1119,6 +1117,7 @@ class PayPal extends PaymentModule
                 'use_mobile'       => true,
                 'PayPal_lang_code' => (isset($isoLang[$this->context->language->iso_code])) ? $isoLang[$this->context->language->iso_code] : 'en_US',
                 'params'           => $params,
+                'landing_page'     => Configuration::get(static::WEBSITE_PAYMENTS_STANDARD_LANDING_PAGE_TYPE)
             ]
         );
 

--- a/paypal.php
+++ b/paypal.php
@@ -377,12 +377,20 @@ class PayPal extends PaymentModule
 
                 if (Tools::getValue(static::WEBSITE_PAYMENTS_STANDARD_ENABLED)) {
                     $standardProfile = $rest->createWebProfile(PayPalRestApi::STANDARD_PROFILE);
-                    if ($standardProfile) {
-                        if (Tools::getValue(static::LIVE)) {
+                    if (Tools::getValue(static::LIVE)) {
+                        if ($standardProfile) {
                             Configuration::updateValue(static::STANDARD_WEBSITE_PROFILE_ID_LIVE, $standardProfile);
                         }
                         else {
+                            Configuration::deleteByName(static::STANDARD_WEBSITE_PROFILE_ID_LIVE);
+                        }
+                    }
+                    else {
+                        if ($standardProfile) {
                             Configuration::updateValue(static::STANDARD_WEBSITE_PROFILE_ID, $standardProfile);
+                        }
+                        else {
+                            Configuration::deleteByName(static::STANDARD_WEBSITE_PROFILE_ID);
                         }
                     }
                 }
@@ -394,12 +402,20 @@ class PayPal extends PaymentModule
 
                 if (Tools::getValue(static::WEBSITE_PAYMENTS_PLUS_ENABLED)) {
                     $plusProfile = $rest->createWebProfile(PayPalRestApi::PLUS_PROFILE);
-                    if ($plusProfile) {
-                        if (Tools::getValue(static::LIVE)) {
+                    if (Tools::getValue(static::LIVE)) {
+                        if ($plusProfile) {
                             Configuration::updateValue(static::PLUS_WEBSITE_PROFILE_ID_LIVE, $plusProfile);
                         }
                         else {
+                            Configuration::deleteByName(static::PLUS_WEBSITE_PROFILE_ID_LIVE);
+                        }
+                    }
+                    else {
+                        if ($plusProfile) {
                             Configuration::updateValue(static::PLUS_WEBSITE_PROFILE_ID, $plusProfile);
+                        }
+                        else {
+                            Configuration::deleteByName(static::PLUS_WEBSITE_PROFILE_ID);
                         }
                     }
                 }
@@ -411,12 +427,20 @@ class PayPal extends PaymentModule
 
                 if (Tools::getValue(static::EXPRESS_CHECKOUT_ENABLED)) {
                     $expressCheckoutProfile = $rest->createWebProfile(PayPalRestApi::EXPRESS_CHECKOUT_PROFILE);
-                    if ($expressCheckoutProfile) {
-                        if (Tools::getValue(static::LIVE)) {
+                    if (Tools::getValue(static::LIVE)) {
+                        if ($expressCheckoutProfile) {
                             Configuration::updateValue(static::EXPRESS_CHECKOUT_WEBSITE_PROFILE_ID_LIVE, $expressCheckoutProfile);
                         }
                         else {
+                            Configuration::deleteByName(static::EXPRESS_CHECKOUT_WEBSITE_PROFILE_ID_LIVE);
+                        }
+                    }
+                    else {
+                        if ($expressCheckoutProfile) {
                             Configuration::updateValue(static::EXPRESS_CHECKOUT_WEBSITE_PROFILE_ID, $expressCheckoutProfile);
+                        }
+                        else {
+                            Configuration::deleteByName(static::EXPRESS_CHECKOUT_WEBSITE_PROFILE_ID);
                         }
                     }
                 }

--- a/paypal.php
+++ b/paypal.php
@@ -131,7 +131,7 @@ class PayPal extends PaymentModule
         $this->author = 'thirty bees';
 
         $this->currencies = true;
-        $this->currencies_mode = 'radio';
+        $this->currencies_mode = 'checkbox';
 
         parent::__construct();
 

--- a/views/templates/admin/profiles_correct.tpl
+++ b/views/templates/admin/profiles_correct.tpl
@@ -19,7 +19,7 @@
 <br />
 {l s='All profiles have been loaded correctly:' mod='paypal'}
 <ul>
-	<li>Website Payments Standard: {$standardProfile|escape:'htmlall':'UTF-8'}</li>
-	<li>Website Payments Plus: {$plusProfile|escape:'htmlall':'UTF-8'}</li>
-	<li>Express Checkout: {$expressCheckoutProfile|escape:'htmlall':'UTF-8'}</li>
+	{if !empty($standardProfile)}<li>Website Payments Standard: {$standardProfile|escape:'htmlall':'UTF-8'}</li>{/if}
+	{if !empty($plusProfile)}<li>Website Payments Plus: {$plusProfile|escape:'htmlall':'UTF-8'}</li>{/if}
+	{if !empty($expressCheckoutProfile)}<li>Express Checkout: {$expressCheckoutProfile|escape:'htmlall':'UTF-8'}</li>{/if}
 </ul>

--- a/views/templates/admin/profiles_missing.tpl
+++ b/views/templates/admin/profiles_missing.tpl
@@ -17,9 +17,10 @@
 *}
 {l s='In order to provide the best checkout experience, all profiles have to be loaded and available.' mod='paypal'}<br />
 <br />
-{l s='Unfortunately, some profiles are missing:' mod='paypal'}
+{l s='Unfortunately, some profiles could not be created:' mod='paypal'}
 <ul>
-	{if $standardProfileNeeded}<li>Website Payments Standard: {$standardProfile|escape:'htmlall':'UTF-8'}</li>{/if}
-	{if $plusProfileNeeded}<li>Website Payments Plus: {$plusProfile|escape:'htmlall':'UTF-8'}</li>{/if}
-	{if $expressCheckoutProfileNeeded}<li>Express Checkout: {$expressCheckoutProfile|escape:'htmlall':'UTF-8'}</li>{/if}
+	{if $standardProfileNeeded}<li>Website Payments Standard: {if empty($standardProfile)}<em>{l s='missing' mod='paypal'}</em>{else}{$standardProfile|escape:'htmlall':'UTF-8'}{/if}</li>{/if}
+	{if $plusProfileNeeded}<li>Website Payments Plus: {if empty($plusProfile)}<em>{l s='missing' mod='paypal'}</em>{else}{$plusProfile|escape:'htmlall':'UTF-8'}{/if}</li>{/if}
+	{if $expressCheckoutProfileNeeded}<li>Express Checkout: {if empty($expressCheckoutProfile)}<em>{l s='missing' mod='paypal'}</em>{else}{$expressCheckoutProfile|escape:'htmlall':'UTF-8'}{/if}</li>{/if}
 </ul>
+{l s='This is most likely caused by existing profiles with same name, likely from another Thirty Bees instance. Try creating a new, empty REST API app in the PayPal developer portal.' mod='paypal'}

--- a/views/templates/admin/profiles_missing.tpl
+++ b/views/templates/admin/profiles_missing.tpl
@@ -19,7 +19,7 @@
 <br />
 {l s='Unfortunately, some profiles are missing:' mod='paypal'}
 <ul>
-	<li>Website Payments Standard: {$standardProfile|escape:'htmlall':'UTF-8'}</li>
-	<li>Website Payments Plus: {$plusProfile|escape:'htmlall':'UTF-8'}</li>
-	<li>Express Checkout: {$expressCheckoutProfile|escape:'htmlall':'UTF-8'}</li>
+	{if $standardProfileNeeded}<li>Website Payments Standard: {$standardProfile|escape:'htmlall':'UTF-8'}</li>{/if}
+	{if $plusProfileNeeded}<li>Website Payments Plus: {$plusProfile|escape:'htmlall':'UTF-8'}</li>{/if}
+	{if $expressCheckoutProfileNeeded}<li>Express Checkout: {$expressCheckoutProfile|escape:'htmlall':'UTF-8'}</li>{/if}
 </ul>

--- a/views/templates/front/paypal_loginjs.tpl
+++ b/views/templates/front/paypal_loginjs.tpl
@@ -46,7 +46,7 @@
 			window.paypal.login.render({
 				appid: '{$client_id|escape:'javascript':'UTF-8'}',
 				authend: {if !$live}'sandbox'{else}''{/if},
-				scopes: 'openid profile email address phone https://uri.paypal.com/services/paypalattributes https://uri.paypal.com/services/expresscheckout',
+				scopes: 'openid profile email address https://uri.paypal.com/services/paypalattributes https://uri.paypal.com/services/expresscheckout',
 				containerid: 'buttonPaypalLogin1',
 				theme: {if $login_theme}'blue'{else}'neutral'{/if},
 				returnurl: '{$return_link|escape:'javascript':'UTF-8'}',

--- a/views/templates/hook/express_checkout_payment.tpl
+++ b/views/templates/hook/express_checkout_payment.tpl
@@ -23,23 +23,19 @@
   <div class="col-xs-12 col-md-12">
     <p class="payment_module paypal">
       <a href="{$link->getModuleLink('paypal', 'expresscheckout', [], true)|escape:'htmlall':'UTF-8'}" title="{l s='Pay with PayPal' mod='paypal'}">
-        <img src="{$module_dir|escape:'htmlall':'UTF-8'}views/img/default_logos/default_horizontal_large.png" alt="{l s='Pay with your card or your PayPal account' mod='paypal'}" width="220px" height="64px"/>
+        {if $landing_page == 'login'}
+        <img src="{$module_dir|escape:'htmlall':'UTF-8'}logo.png" alt="{l s='Pay with your PayPal account' mod='paypal'}" width="64" height="64"/>
+        {l s='Pay with your PayPal account' mod='paypal'}
+        {else}
+        <img src="{$module_dir|escape:'htmlall':'UTF-8'}views/img/default_logos/default_horizontal_large.png" alt="{l s='Pay with your card or your PayPal account' mod='paypal'}" width="220" height="64"/>
         {l s='Pay with your card or your PayPal account' mod='paypal'}
+        {/if}
       </a>
     </p>
   </div>
 </div>
 
 <style>
-  p.payment_module.paypal a {
-    padding: 10px;
-    background-color: #FBFBFB;
-  }
-
-  p.payment_module.paypal img {
-    height: 64px;
-  }
-
   p.payment_module.paypal a:hover {
     background-color: #f6f6f6;
   }


### PR DESCRIPTION
This PR contains:
* Bugfix for address not being transferred to PayPal (probably fixes #26)
* Use HTTPS logo instead of HTTP logo as most modern browsers do not show the logo otherwise (as PayPal uses HTTPS only)
* The final button on PayPal side is now called "Pay" (not "Continue" as before) for standard and plus payment
* Only create payment experience web profiles for actually configured payment types (standard/plus/express checkout)
* Do not ever delete a payment profile not created by this module (otherwise if two Thirty Bees instances access the same PayPal web app (e.g. by accident) the two instances break each other)
* Allow to configure landing page on PayPal side (directly allow paying incl. credit card, or ask use to login with PayPal account first)
* Hide credit card logos and text on Thirty Bees payment page depending on selected landing page
* Resize logo if it's bigger than PayPal expects
* Fixed PayPal login which was broken due to probably changed PayPal API (attributes account_type, zoneinfo and age_range are not exposed anymore and also the phone scope is not valid).