### PR TITLE
More Usable Transaction Id

### DIFF
--- a/classes/PayPalOrder.php
+++ b/classes/PayPalOrder.php
@@ -157,6 +157,23 @@ class PayPalOrder extends ObjectModel
     public static function getTransactionDetails($payment)
     {
         $transactionId = pSQL($payment->id);
+
+        try {
+            // Search for a more usable transaction id in the payment object
+            $relatedResources = $payment->transactions[0]->related_resources;
+            foreach ($relatedResources as $rr)
+            {
+                if (!is_null($rr->sale))
+                {
+                    $transactionId = $rr->sale->id;
+                    break;
+                }
+            }
+        }
+        catch (Exception $e) {
+            // Continue with $payment->id
+        }
+
         $paymentId = pSQL($payment->id);
         $payerId = pSQL($payment->payer->payer_info->payer_id);
         $transaction = $payment->transactions[0];

--- a/classes/PayPalOrder.php
+++ b/classes/PayPalOrder.php
@@ -157,10 +157,11 @@ class PayPalOrder extends ObjectModel
     public static function getTransactionDetails($payment)
     {
         $transactionId = pSQL($payment->id);
+        $transaction = $payment->transactions[0];
 
         try {
             // Search for a more usable transaction id in the payment object
-            $relatedResources = $payment->transactions[0]->related_resources;
+            $relatedResources = $transaction->related_resources;
             foreach ($relatedResources as $rr)
             {
                 if (!is_null($rr->sale))
@@ -176,7 +177,6 @@ class PayPalOrder extends ObjectModel
 
         $paymentId = pSQL($payment->id);
         $payerId = pSQL($payment->payer->payer_info->payer_id);
-        $transaction = $payment->transactions[0];
 
         return [
             'currency' => pSQL($payment->transactions[0]->amount->currency),


### PR DESCRIPTION
The current transaction id that is placed in the database is entirely unusable (unless I'm out of the loop).  I can't seem to correlate it to the actual transaction in my paypal at all. 

Take for example this transaction with this ID: 
<img width="987" height="230" alt="image" src="https://github.com/user-attachments/assets/53896f8b-a957-4153-99c9-af89659ead2e" />
Searching for this in the PayPal dashboard finds only this $0.00 USD transaction and not the actual $84.96 USD transaction that it should. 

With the following code changes we find the actual transaction id for the actual payment, notice a different format: 
<img width="989" height="203" alt="image" src="https://github.com/user-attachments/assets/ea0f222c-c8f3-4b2e-84e4-11e9b5dde790" />
Using this ID in the search actually results in finding the transaction, and can be directly linked with https://www.paypal.com/activity/payment/{TransactionId}

<img width="1408" height="233" alt="image" src="https://github.com/user-attachments/assets/d3a24e7b-d840-4bb7-af21-958c3bfad9d1" />

Unless I'm missing something, this seems like the much more useful ID to be storing and tracking